### PR TITLE
Add support for tokenized purchase requests

### DIFF
--- a/src/Message/CreditCardRequest.php
+++ b/src/Message/CreditCardRequest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Omnipay\Dummy\Message;
 
 use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\Common\Message\ResponseInterface;
 
 /**
  * Dummy Authorize/Purchase Request
@@ -14,17 +14,26 @@ class CreditCardRequest extends AbstractRequest
 {
     public function getData()
     {
-        $this->validate('amount', 'card');
+        if ($this->getCardReference()) {
+            $this->validate('amount', 'cardReference');
+        } else {
+            $this->validate('amount', 'card');
 
-        $this->getCard()->validate();
+            $this->getCard()->validate();
+        }
 
         return array('amount' => $this->getAmount());
     }
 
     public function sendData($data)
     {
+        if ($this->getCardReference()) {
+            $data['success'] = 0 === substr($this->getCardReference(), -1, 1) % 2;
+        } else {
+            $data['success'] = 0 === substr($this->getCard()->getNumber(), -1, 1) % 2;
+        }
+
         $data['reference'] = uniqid();
-        $data['success'] = 0 === substr($this->getCard()->getNumber(), -1, 1) % 2;
         $data['message'] = $data['success'] ? 'Success' : 'Failure';
 
         return $this->response = new Response($this, $data);

--- a/src/Message/CreditCardRequest.php
+++ b/src/Message/CreditCardRequest.php
@@ -28,7 +28,7 @@ class CreditCardRequest extends AbstractRequest
     public function sendData($data)
     {
         if ($this->getCardReference()) {
-            $data['success'] = 0 === substr($this->getCardReference(), -1, 1) % 2;
+            $data['success'] = 0 === ((int)substr($this->getCardReference(), -1, 1)) % 2;
         } else {
             $data['success'] = 0 === substr($this->getCard()->getNumber(), -1, 1) % 2;
         }

--- a/src/Message/TransactionReferenceRequest.php
+++ b/src/Message/TransactionReferenceRequest.php
@@ -14,12 +14,13 @@ class TransactionReferenceRequest extends AbstractRequest
     public function getData()
     {
         $this->validate('transactionReference');
-        return array('transactionReference' => $this->getTransactionReference());
+        return array('transactionReference' => $this->getTransactionReference(), 'amount' => $this->getAmount());
     }
 
     public function sendData($data)
     {
         $data['reference'] = $this->getTransactionReference();
+        $data['amount'] = $this->getAmount();
         $data['success'] = strpos($this->getTransactionReference(), 'fail') !== false ? false : true;
         $data['message'] = $data['success'] ? 'Success' : 'Failure';
 

--- a/tests/Message/CreditCardRequestTest.php
+++ b/tests/Message/CreditCardRequestTest.php
@@ -59,7 +59,7 @@ class CreditCardRequestTest extends TestCase
 
     public function testTokenSuccess()
     {
-        // card numbers ending in even number should be successful
+        // tokens ending in even number should be successful
         $options = array(
             'amount' => '10.00',
             'cardReference' => '6b34e45d-4015-4864-a8c5-cd7a2df7a3d4',
@@ -73,9 +73,25 @@ class CreditCardRequestTest extends TestCase
         $this->assertSame('Success', $response->getMessage());
     }
 
+    public function testNonNumericTokenSuccess()
+    {
+        // tokens ending in non-numeric string should be successful
+        $options = array(
+            'amount' => '10.00',
+            'cardReference' => 'c6acca78-1eb0-415b-a4ed-d766a59563cf',
+        );
+        $response = $this->gateway->authorize($options)->send();
+
+        $this->assertInstanceOf('\Omnipay\Dummy\Message\Response', $response);
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNotEmpty($response->getTransactionReference());
+        $this->assertSame('Success', $response->getMessage());
+    }
+
     public function testTokenFailure()
     {
-        // card numbers ending in even number should be successful
+        // tokens ending in odd number should be declined
         $options = array(
             'amount' => '10.00',
             'cardReference' => 'a9d7105f-cbdd-4984-8591-35b28b739e59',

--- a/tests/Message/CreditCardRequestTest.php
+++ b/tests/Message/CreditCardRequestTest.php
@@ -57,4 +57,36 @@ class CreditCardRequestTest extends TestCase
         $this->assertSame('Failure', $response->getMessage());
     }
 
+    public function testTokenSuccess()
+    {
+        // card numbers ending in even number should be successful
+        $options = array(
+            'amount' => '10.00',
+            'cardReference' => '6b34e45d-4015-4864-a8c5-cd7a2df7a3d4',
+        );
+        $response = $this->gateway->authorize($options)->send();
+
+        $this->assertInstanceOf('\Omnipay\Dummy\Message\Response', $response);
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNotEmpty($response->getTransactionReference());
+        $this->assertSame('Success', $response->getMessage());
+    }
+
+    public function testTokenFailure()
+    {
+        // card numbers ending in even number should be successful
+        $options = array(
+            'amount' => '10.00',
+            'cardReference' => 'a9d7105f-cbdd-4984-8591-35b28b739e59',
+        );
+        $response = $this->gateway->authorize($options)->send();
+
+        $this->assertInstanceOf('\Omnipay\Dummy\Message\Response', $response);
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNotEmpty($response->getTransactionReference());
+        $this->assertSame('Failure', $response->getMessage());
+    }
+
 }


### PR DESCRIPTION
Some gateways allow the `purchase()` method to be called while providing only a **cardReference** "token" rather than an entire **\Omnipay\Common\CreditCard** object. These are mostly used for PCI-compliant card tokenization processes (e.g. Stripe). This allows the Dummy driver to be used in place of these token-driven gateways.